### PR TITLE
Pin NAC server to Alpine 3.12

### DIFF
--- a/images/network-access-control-server/Dockerfile
+++ b/images/network-access-control-server/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.12


### PR DESCRIPTION
The current version (Alpine 3.14) has a bug which causes Radsec to fail.
Pinning the individual dependencies will be a lot of maintenance
overhead. Revert to using Alpine 3.12 until a fix is introduced in later
versions.