### PR TITLE
Use Ubuntu instead of Alpine for the NAC server base image

### DIFF
--- a/images/network-access-control-server/Dockerfile
+++ b/images/network-access-control-server/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.12
+FROM ubuntu:20.04


### PR DESCRIPTION
A bug in the Openssl version on Alpine is preventing radsec connections.
Use Ubuntu instead of Alpine, which supports both Python3 and Radsec.