### PR TITLE
Build and publish latest version of NGINX

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,1 +1,1 @@
-FROM nginx:1.19.8-alpine
+FROM nginx:1.21.4-alpine


### PR DESCRIPTION
A number of outdated packages and vulnerabilities exist
in the previous versions of this NGINX Alpine image.

Publish the latest version, keeping all the previous versions for
backwards compatibility.