### PR TITLE
Remove NACS base images

### DIFF
--- a/images/network-access-control-integration-tests/Dockerfile
+++ b/images/network-access-control-integration-tests/Dockerfile
@@ -1,1 +1,0 @@
-FROM ruby:3.0.2-alpine3.14

--- a/images/network-access-control-server/Dockerfile
+++ b/images/network-access-control-server/Dockerfile
@@ -1,1 +1,0 @@
-FROM ubuntu:20.04

--- a/images/network-access-control-test-certs/Dockerfile
+++ b/images/network-access-control-test-certs/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.13.0


### PR DESCRIPTION
We can now use MoJ licenses and pull images from Dockerhub directly