### PR TITLE
:sparkles: New Make target to publish an individual image to ECR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,7 @@ check-container-registry-account-id:
 build-and-publish: check-container-registry-account-id
 	./scripts/build_and_publish.sh
 
+publish-specific: check-container-registry-account-id
+	./scripts/build_and_publish_individual_image.sh $(IMAGE)
+
 .PHONY: build-and-publish check-container-registry-account-id

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ To run this repo you will need:
 3. Change image version to desired e.g. `FROM grafana/grafana:8.3.3` to `FROM grafana/grafana:8.3.4`
 4. Create a Pull Request wait for review, merge and then switch back to main.
 5. Run: `make build-and-publish` this pulls down all images and then pushes them into ECR.
-6. The running container will not update until container services are redeployed. For Elastic Container Service, go to the service, select the `Update` button and leave all defaults except tick the box by `Force New Deployment` this will recreate all the running containers with the new image.  
+6. To publish a single image to ECR you can run ` make publish-specific IMAGE="<<image-name>>"` NOTE : `<<image-name>>` must match the folder name where the Dockerfile is stored.
+7. The running container will not update until container services are redeployed. For Elastic Container Service, go to the service, select the `Update` button and leave all defaults except tick the box by `Force New Deployment` this will recreate all the running containers with the new image.  

--- a/scripts/build_and_publish_individual_image.sh
+++ b/scripts/build_and_publish_individual_image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd ./images 
+
+image_to_push=$1
+
+for image_name in * ; do
+  if [ ${image_name} = $1 ]; then
+    docker build -t $image_name ./$image_name
+    tag=$( < $image_name/Dockerfile cut -f2 -d ' ' | sed 's/[^a-zA-Z0-9]/-/g' )
+    repository_url=${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/$image_name
+    aws ecr get-login-password | docker login --username AWS --password-stdin ${repository_url}
+    docker tag $image_name ${repository_url}:$tag
+    docker push ${repository_url}:$tag  
+    docker tag $image_name ${repository_url}:latest
+    docker push ${repository_url}:latest
+  fi
+  
+done


### PR DESCRIPTION
As pushing all images at once takes a while, I've added a new Make target which allows updating a single image.  This should make Dependabots quicker until we wrap this in a Github Action.